### PR TITLE
fix: clean .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,8 @@
-# Node rules:
-## Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
+# use https://github.com/github/gitignore
 
-## Dependency directory
-## Commenting this out is preferred by some people, see
-## https://docs.npmjs.com/misc/faq#should-i-check-my-node_modules-folder-into-git
-node_modules
+# see
+# https://github.com/github/gitignore/tree/master/Global
+# https://kmyk.github.io/blog/blog/2020/11/08/man-gitignore/
 
-# Book build output
-_book
+# @todo gitignoreについてチームメンバーと合意を取りましょう
 
-# eBook build output
-*.epub
-*.mobi
-*.pdf


### PR DESCRIPTION
<!--
PULL_REQUEST_TEMPLATE

see: [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
日本語訳：　[GitHub「完璧なプルリクの書き方を教えるぜ」 - Qiita](http://qiita.com/umanoda/items/93aec41213f8e3ce14c8)
-->

## 目的

必要ない設定があったのと、見直しをしたので gitignore について書きなおした。

- https://github.com/github/gitignore を使う
- OS固有ファイルなどは https://github.com/github/gitignore/tree/master/Global に従う
- チームで合意をとって含めるもの、含めないものを決める

## 必要なフィードバック

gitignore についてチームで合意を取るとかしたほうがいい気がするけど今更感満載。
.DS_Store とかOS固有のやつはローカルにしとけってのはいいんだけど、.idea はまだちょっと納得してない。
https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
ローカルにこれを設定しても、プロジェクト.iml や複数のファイルが残る。
チーム全員が idea を使っているならいいけど、そうじゃないならリポジトリに含めなくていいことにならないだろうかとか。

結局のところ、ignoreしたいものはなんでもいれておけばいいじゃん派を撲滅するには至らないし、
チーム毎に事情が異なることを考えると完璧な指針を示すこともできないし、その合意を取るのも難しい気がする。
